### PR TITLE
reduce writes

### DIFF
--- a/index.js
+++ b/index.js
@@ -157,19 +157,20 @@ function digraph(db, stream, options) {
 
     return tables(db)
       .then(ts => {
-        for (let table of ts) {
-          stream.write(`  ${node(table)}\n`)
-        }
+        const nodes = []
+        const edges = []
 
         for (let table of ts) {
+          nodes.push(`  ${node(table)}\n`)
           for (let fk of table.fk) {
-            stream.write(`  ${edge(table, fk, options)}\n`)
+            edges.push(`  ${edge(table, fk, options)}\n`)
           }
         }
+  
+        stream.write(nodes.join('').concat(edges.join(''),'}\n'))
 
         return ts
       })
-      .then(() => { stream.write('}\n') })
       .then(resolve, reject)
   })
 }


### PR DESCRIPTION
Attempting to generate a viz of my database schema would fail every time, as most attempts to write to the filestream would fail (presumably because each chunk was too large to be written before the next call). This PR works around this issue by writing the entire schema at once.

I also merged the two for loops, as they seemed to be redundant.