### PR TITLE
Adds support for tracking indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,14 @@ Usage: sqleton [options] <database>
 
 Options:
   -L, --layout      The layout command
-      [choices: "neato", "dot", "circo", "fdp", "osage", "sfdp", "twopi"]
-                                                         [default: "fdp"]
-  -e, --edge-labels Label foreign key edges                     [boolean]
-  -t, --title       Optional title string
-  -f, --font        The font to use                [default: "Helvetica"]
-  -d, --direction   Graph direction [choices: "TB", "LR"] [default: "LR"]
-  -o, --out         Output file (determines output format)     [required]
+       [choices: "neato", "dot", "circo", "fdp", "osage", "sfdp", "twopi"]
+                                                          [default: "fdp"]
+  -e, --edge-labels  Label foreign key edges                     [boolean]
+  -t, --title        Optional title string
+  -f, --font         The font to use                [default: "Helvetica"]
+  -d, --direction    Graph direction [choices: "TB", "LR"] [default: "LR"]
+  -o, --out          Output file (determines output format)     [required]
+      --skip-index   Skip writing table indexes                  [boolean]
 ```
 
 ## Fine-Tuning

--- a/bin/sqleton
+++ b/bin/sqleton
@@ -43,6 +43,11 @@ const argv = require('yargs')
       'Output file (determines output format)'
   })
 
+  .option('skip-index', {
+    type: 'boolean',
+    describe: 'Skip writing table indexes'
+  })
+
   .argv
 
 


### PR DESCRIPTION
It's useful for me to know what indexes exist on my tables for the purpose of troubleshooting performance issues, so I added it to this project! You can see it in use [here](https://github.com/kieraneglin/pinchflat/blob/master/priv/repo/erd.png)

There's a new flag (`--skip-index`) if you want to ignore indexes which effectively keeps the current behaviour.

**Default output:**

![Screenshot 2024-05-22 at 10 08 47 AM](https://github.com/inukshuk/sqleton/assets/569917/468aeacc-7bc0-4eb9-867f-2b6a5d995fa5)

**With `--skip-index`:**

![Screenshot 2024-05-22 at 10 09 28 AM](https://github.com/inukshuk/sqleton/assets/569917/caf09c50-a2dc-4498-950b-69236dea5422)
